### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -20,7 +20,7 @@ jobs:
       id: get_version
       run: echo ::set-env name=RELEASE_VERSION::$(echo $(grep "VERSION=" Dockerfile|cut -d"=" -f2))
     - name: Build and publish images
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: hyr326/ldap-user-manager
         tags: "latest"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore